### PR TITLE
Fix typo in artifact information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For pure Java apps:
 ```
 <dependency>
   <groupId>org.whispersystems</groupId>
-  <artifactId>axolotl-java</groupId>
+  <artifactId>axolotl-java</artifactId>
   <version>(latest version number)</version>
 </dependency>
 ```


### PR DESCRIPTION
The `<artifactID>`-tag was wrongly closed by an `</groupId>` tag in the "pure Java apps" section of the README.md file.

Looks like a typical copy&paste issue :)